### PR TITLE
fix(headers): prevent mutation of headers in upload function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ export class BunnyCdnStream {
     options.url += `/library/${this.options.videoLibrary}/videos/${videoId}`;
     options.method = 'PUT';
     options.data = file;
-    options.headers['Content-Type'] = 'application/octet-stream';
+    options.headers = { ...options.headers, 'Content-Type': 'application/octet-stream' };
 
     return this.request<BunnyCdnStream.UploadVideoResponse>(options, 'upload');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,7 +335,8 @@ export class BunnyCdnStream {
 
   private getOptions() {
     return {
-      ...this.axiosOptions
+      ...this.axiosOptions,
+      headers: {...this.axiosOptions.headers}
     };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,7 +336,7 @@ export class BunnyCdnStream {
   private getOptions() {
     return {
       ...this.axiosOptions,
-      headers: {...this.axiosOptions.headers}
+      headers: { ...this.axiosOptions.headers }
     };
   }
 }


### PR DESCRIPTION
This PR fixes a breaking bug where the header gets mutated cause only the request definition is copied and the headers are referenced.

What can happen here (and what happened to us) is that:

1. a client gets created
2. a video gets uploaded from file (octed-stream)
3. a video gets created but the content-type is now octed-stream and therefore breaks!