### PR TITLE
fix: use default import for the library "file-type" to support ESM

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosError, AxiosHeaders, AxiosRequestConfig, AxiosRequestHeaders } from 'axios';
-import { fromBuffer } from 'file-type';
+import fileType from 'file-type';
 import { ReadStream } from 'fs';
 import { createHash } from 'node:crypto';
 import { BunnyCdnStreamError } from './error';
@@ -310,7 +310,7 @@ export class BunnyCdnStream {
 
     if (typeof thumbnail !== 'string')
       options.headers['Content-Type'] =
-        thumbnail instanceof ReadStream ? 'application/octet-stream' : (ct || (await fromBuffer(thumbnail)) || { mime: 'image/jpg' }).mime;
+        thumbnail instanceof ReadStream ? 'application/octet-stream' : (ct || (await fileType.fromBuffer(thumbnail)) || { mime: 'image/jpg' }).mime;
 
     options.url += `/library/${this.options.videoLibrary}/videos/${videoId}/thumbnail`;
     options.method = 'POST';


### PR DESCRIPTION
Hi,
The library "file-type" utilises CommonJS and has a default export that contains everything. I think that's the reason why it is not possible to import one single function from it.

This resolves #86 . I tried replicating that issue on my machine and it occurs only when using ESM.
My regards.
