### PR TITLE
fix(api): Use query params instead of body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,7 @@ export class BunnyCdnStream {
   ) {
     const options = this.getOptions();
     options.url += `/library/${this.options.videoLibrary}/statistics`;
-    options.data = JSON.stringify({ ...data, videoGuid: videoId });
+    options.params = { ...data, videoGuid: videoId };
 
     return this.request<BunnyCdnStream.VideoStatisticsResponse>(options, 'fetch');
   }


### PR DESCRIPTION
## 📑 Description
The getVideoStatistics arguments were passed using body, but the Bunny API uses query string for this method.
The consequence was to have no argument passed to the API and return a global information (the whole library) instead of a specific video by its GUID.
The fix changes where the data are put: in the query string instead of the body.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
The tests should have seen it but the cost to update the test for this case is high: it would require to upload 2 videos (easy) but also to simulate watch time (harder) to distinguish between the global stats and the specific stats which have both '0' values because no watch time is set.
To me it's not worth it.