### PR TITLE
fix(tus): converts TUS AuthorizationExpire timestamp to seconds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -696,9 +696,9 @@ export class BunnyCdnStream {
 		expirationDate?: Date,
 	): Promise<BunnyCdnStream.CreateDirectUpload> {
 		// create a video
-		const expirationTimestamp = (
-			expirationDate || new Date(Date.now() + 60000)
-		).getTime();
+		const expirationTimestamp = Math.floor(
+			(expirationDate || new Date(Date.now() + 60000)).getTime() / 1000,
+		);
 		const video = await this.createVideo(data);
 		const hash = this.generateTUSHash(video.guid, expirationTimestamp);
 


### PR DESCRIPTION
# Description

A simple change that changes the TUS AuthorizationExpire header from milliseconds to seconds. This is because Bunny has sent out an email saying they **won't** accept milliseconds after June 15th (2025). Can't find where this is explicitly told in the docs though...

## Type of change

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)
